### PR TITLE
jwt token 발급 기능 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 .DS_Store
 
 # yml
-src/main/resources/application-prod.yml
+src/main/resources/application-production.yml

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 .DS_Store
 
 # yml
-src/main/resources/application-production.yml
+src/main/resources/config/env.yml

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'com.auth0:java-jwt:3.19.1'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'

--- a/src/main/java/com/highgag/sbook/SbookApplication.java
+++ b/src/main/java/com/highgag/sbook/SbookApplication.java
@@ -2,6 +2,8 @@ package com.highgag.sbook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @SpringBootApplication
 public class SbookApplication {

--- a/src/main/java/com/highgag/sbook/bookmark/domain/Bookmark.java
+++ b/src/main/java/com/highgag/sbook/bookmark/domain/Bookmark.java
@@ -1,6 +1,8 @@
-package com.highgag.sbook.domain;
+package com.highgag.sbook.bookmark.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.highgag.sbook.bookmarkList.domain.BookmarkList;
+import com.highgag.sbook.user.domain.User;
 import lombok.Getter;
 
 import javax.persistence.*;

--- a/src/main/java/com/highgag/sbook/bookmark/domain/Importance.java
+++ b/src/main/java/com/highgag/sbook/bookmark/domain/Importance.java
@@ -1,4 +1,4 @@
-package com.highgag.sbook.domain;
+package com.highgag.sbook.bookmark.domain;
 
 public enum Importance {
     ONE(1),

--- a/src/main/java/com/highgag/sbook/bookmarkList/domain/BookmarkGroup.java
+++ b/src/main/java/com/highgag/sbook/bookmarkList/domain/BookmarkGroup.java
@@ -1,6 +1,7 @@
-package com.highgag.sbook.domain;
+package com.highgag.sbook.bookmarkList.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.highgag.sbook.bookmark.domain.Bookmark;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -9,14 +10,14 @@ import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
-public class ListUser {
+public class BookmarkGroup {
     @Id
     @GeneratedValue
     private Long id;
 
     @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "bookmark_id")
+    private Bookmark bookmark;
 
     @JsonIgnore
     @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/highgag/sbook/bookmarkList/domain/BookmarkList.java
+++ b/src/main/java/com/highgag/sbook/bookmarkList/domain/BookmarkList.java
@@ -1,11 +1,9 @@
-package com.highgag.sbook.domain;
+package com.highgag.sbook.bookmarkList.domain;
 
+import com.highgag.sbook.user.domain.User;
 import lombok.Getter;
 
 import javax.persistence.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static javax.persistence.FetchType.LAZY;
 

--- a/src/main/java/com/highgag/sbook/bookmarkList/domain/ListUser.java
+++ b/src/main/java/com/highgag/sbook/bookmarkList/domain/ListUser.java
@@ -1,6 +1,8 @@
-package com.highgag.sbook.domain;
+package com.highgag.sbook.bookmarkList.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.highgag.sbook.bookmarkList.domain.BookmarkList;
+import com.highgag.sbook.user.domain.User;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -9,14 +11,14 @@ import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
-public class BookmarkGroup {
+public class ListUser {
     @Id
     @GeneratedValue
     private Long id;
 
     @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "bookmark_id")
-    private Bookmark bookmark;
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @JsonIgnore
     @ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)

--- a/src/main/java/com/highgag/sbook/common/auth/PrincipalDetails.java
+++ b/src/main/java/com/highgag/sbook/common/auth/PrincipalDetails.java
@@ -1,0 +1,52 @@
+package com.highgag.sbook.common.auth;
+
+import com.highgag.sbook.user.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+public class PrincipalDetails implements UserDetails {
+    private User user;
+
+    public PrincipalDetails(User user){
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/highgag/sbook/common/auth/PrincipalDetails.java
+++ b/src/main/java/com/highgag/sbook/common/auth/PrincipalDetails.java
@@ -3,8 +3,10 @@ package com.highgag.sbook.common.auth;
 import com.highgag.sbook.user.domain.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 @Getter
@@ -17,7 +19,9 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(new SimpleGrantedAuthority(user.getRole().toString()));
+        return authorities;
     }
 
     @Override

--- a/src/main/java/com/highgag/sbook/common/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/highgag/sbook/common/auth/PrincipalDetailsService.java
@@ -17,9 +17,7 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        System.out.println("PrincipalDetailsService의 loadUserByUsername()");
         User userEntity = userRepository.findByEmail(username);
-        System.out.println("userEntity = " + userEntity);
         return new PrincipalDetails(userEntity);
     }
 }

--- a/src/main/java/com/highgag/sbook/common/auth/PrincipalDetailsService.java
+++ b/src/main/java/com/highgag/sbook/common/auth/PrincipalDetailsService.java
@@ -1,0 +1,25 @@
+package com.highgag.sbook.common.auth;
+
+import com.highgag.sbook.user.domain.User;
+import com.highgag.sbook.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+// http://localhost:8080/login 에서 동작 -> spring security에서 정해놓은 것 (기본 login url)
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        System.out.println("PrincipalDetailsService의 loadUserByUsername()");
+        User userEntity = userRepository.findByEmail(username);
+        System.out.println("userEntity = " + userEntity);
+        return new PrincipalDetails(userEntity);
+    }
+}

--- a/src/main/java/com/highgag/sbook/common/config/CorsConfig.java
+++ b/src/main/java/com/highgag/sbook/common/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.highgag.sbook.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter(){
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true); // 내 서버가 응답을 할 때 json을 자바스크립트에서 처리할 수 있게 할지를 설정하는 것
+        config.addAllowedOrigin("*"); // 모든 ip의 응답을 허용하겠다
+        config.addAllowedHeader("*"); // 모든 header의 응답을 허용하겠다
+        config.addAllowedMethod("*"); // 모든 method(post, get, put, delete, patch) 요청을 허용하겠다
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/highgag/sbook/common/config/SecurityConfig.java
+++ b/src/main/java/com/highgag/sbook/common/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.highgag.sbook.common.config;
+
+import com.highgag.sbook.common.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final CorsFilter corsFilter;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception{
+//        http.addFilterBefore(new MyFilter1(), BasicAuthenticationFilter.class);
+
+        http.addFilter(corsFilter) // 모든 요청은 이 필터를 탄다, @CrossOrigin(인증 X, 시큐리티 필터에 인증
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 x -> JWT 사용
+                .and()
+
+                .formLogin().disable() // form tag 만들어서 로그인 안 한다
+                .httpBasic().disable() // http basic 방식 : header에 Authorization 에 Id와 pw를 담아 보냄. -> 우리가 사용하는 건 토큰을 담아 보내는 bearer 방식
+
+                .addFilter(new JwtAuthenticationFilter(authenticationManager())) //AuthenticaitonManager을 꼭 parameter로 넘겨줘야 함
+                .authorizeRequests()
+                .antMatchers("/api/v1/user/**")
+                .access("hasRole(Role.USER)")
+                .anyRequest().permitAll();
+    }
+}

--- a/src/main/java/com/highgag/sbook/common/config/SecurityConfig.java
+++ b/src/main/java/com/highgag/sbook/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.highgag.sbook.common.config;
 
 import com.highgag.sbook.common.jwt.JwtAuthenticationFilter;
 import com.highgag.sbook.common.jwt.JwtAuthorizationFilter;
+import com.highgag.sbook.common.jwt.JwtProperties;
 import com.highgag.sbook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +21,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final CorsFilter corsFilter;
     private final UserRepository userRepository;
+    private final JwtProperties jwtProperties;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder(){
@@ -40,7 +42,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .httpBasic().disable()
 
                 .addFilter(authenticationFilter)
-                .addFilter(new JwtAuthorizationFilter(authenticationManager(), userRepository))
+                .addFilter(new JwtAuthorizationFilter(authenticationManager(), jwtProperties, userRepository))
                 .authorizeRequests()
                 .antMatchers("/api/v1/user/**")
                 .access("hasRole('ROLE_USER')")

--- a/src/main/java/com/highgag/sbook/common/dto/GeneralResponse.java
+++ b/src/main/java/com/highgag/sbook/common/dto/GeneralResponse.java
@@ -1,0 +1,14 @@
+package com.highgag.sbook.common.dto;
+
+import lombok.Getter;
+
+@Getter
+public class GeneralResponse {
+    String code;
+    String msg;
+
+    public GeneralResponse(String code, String msg) {
+        this.code = code;
+        this.msg = msg;
+    }
+}

--- a/src/main/java/com/highgag/sbook/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/highgag/sbook/common/jwt/JwtAuthenticationFilter.java
@@ -42,7 +42,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             UsernamePasswordAuthenticationToken authenticationToken
                     = new UsernamePasswordAuthenticationToken(user.getEmail(), user.getPassword());
 
-
             Authentication authentication =
                     authenticationManager.authenticate(authenticationToken);
 
@@ -56,7 +55,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     }
 
     /**
-     * attemptAuthentication  실행 후 인증이 정상적으로 된 경우 아래 함수 실행
+     * attemptAuthentication 실행 후 인증이 정상적으로 된 경우 아래 함수 실행
      * JWT 토큰 발급 -> request한 사용자에게 JWT response header에 담아 보내기
      */
     @Override
@@ -69,10 +68,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         String jwtToken = JWT.create()
                 .withSubject(principalDetails.getUsername())
-                .withExpiresAt(new Date(System.currentTimeMillis() + JwtProperties.EXPIRATION_TIME))
+                .withExpiresAt(new Date(System.currentTimeMillis()+ JwtProperties.EXPIRATION_TIME))
                 .withClaim("id", user.getId())
                 .withClaim("email", user.getEmail())
-                .sign(JwtProperties.SECRET);
+                .sign(Algorithm.HMAC512(JwtProperties.SECRET));
 
         response.addHeader("Authorization", "Bearer " + jwtToken);
     }

--- a/src/main/java/com/highgag/sbook/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/highgag/sbook/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.highgag.sbook.common.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.highgag.sbook.common.auth.PrincipalDetails;
+import com.highgag.sbook.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * login 요청(post) 시 username(email), password 전송하면
+ * UsernamePasswordAuthenticationFilter 동작
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final AuthenticationManager authenticationManager;
+
+    /**
+     * login 요청을 하면 로그인 시도를 위해서 실행 -> email, password 확인 작업
+     */
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        System.out.println("JwtAuthenticationFilter : 로그인 시도 중");
+
+        try {
+            ObjectMapper om = new ObjectMapper();
+            User user = om.readValue(request.getInputStream(), User.class);
+            System.out.println(user.toString());
+
+            UsernamePasswordAuthenticationToken authenticationToken
+                    = new UsernamePasswordAuthenticationToken(user.getEmail(), user.getPassword());
+
+
+            Authentication authentication =
+                    authenticationManager.authenticate(authenticationToken);
+
+            PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+            System.out.println("principalDetails = " + principalDetails.getUser().getEmail());
+
+            System.out.println("===========================");
+            return authentication;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/highgag/sbook/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/highgag/sbook/common/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,66 @@
+package com.highgag.sbook.common.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.highgag.sbook.common.auth.PrincipalDetails;
+import com.highgag.sbook.user.domain.User;
+import com.highgag.sbook.user.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter{
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private UserRepository userRepository;
+
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, UserRepository userRepository) {
+        super(authenticationManager);
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String header = request.getHeader(JwtProperties.HEADER_STRING);
+        if(header == null || !header.startsWith(JwtProperties.TOKEN_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String token = request.getHeader(JwtProperties.HEADER_STRING)
+                .replace(JwtProperties.TOKEN_PREFIX, "");
+
+        String email = JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
+                .getClaim("email").asString();
+        Long id = JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
+                .getClaim("id").asLong();
+
+        if(email != null) {
+            User user = userRepository.findByEmail(email);
+
+            PrincipalDetails principalDetails = new PrincipalDetails(user);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            principalDetails,
+                            null,
+                            principalDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/com/highgag/sbook/common/jwt/JwtProperties.java
+++ b/src/main/java/com/highgag/sbook/common/jwt/JwtProperties.java
@@ -1,0 +1,22 @@
+package com.highgag.sbook.common.jwt;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProperties {
+
+    static String SECRET;
+    static int EXPIRATION_TIME = 864000000; // 10일 (1/1000초)
+    static String TOKEN_PREFIX = "Bearer ";
+    static String HEADER_STRING = "Authorization";
+
+    public static String getSECRET() {
+        return SECRET;
+    }
+
+    @Value("${JWT_SECRET}")
+    public void setSECRET(String value) {
+        SECRET = value;
+    }
+}

--- a/src/main/java/com/highgag/sbook/user/controller/UserApiController.java
+++ b/src/main/java/com/highgag/sbook/user/controller/UserApiController.java
@@ -1,0 +1,26 @@
+package com.highgag.sbook.user.controller;
+
+import com.highgag.sbook.common.dto.GeneralResponse;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import com.highgag.sbook.user.domain.User;
+import com.highgag.sbook.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class UserApiController {
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @PostMapping("join")
+    public GeneralResponse join(@Valid @RequestBody User user){
+        user.saveUser(user.getEmail(), bCryptPasswordEncoder.encode(user.getPassword()));
+        userRepository.save(user);
+        return new GeneralResponse("200", "회원가입 완료");
+    }
+}

--- a/src/main/java/com/highgag/sbook/user/controller/UserApiController.java
+++ b/src/main/java/com/highgag/sbook/user/controller/UserApiController.java
@@ -5,6 +5,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import com.highgag.sbook.user.domain.User;
 import com.highgag.sbook.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,5 +23,19 @@ public class UserApiController {
         user.saveUser(user.getEmail(), bCryptPasswordEncoder.encode(user.getPassword()));
         userRepository.save(user);
         return new GeneralResponse("200", "회원가입 완료");
+    }
+
+    @GetMapping("api/v1/user")
+    public String user(){
+        return "user1";
+    }
+
+    @GetMapping("api/v1/user/1")
+    public String user1(){
+        return "user1";
+    }
+    @GetMapping("api/v1/user/2")
+    public String user2(){
+        return "user1";
     }
 }

--- a/src/main/java/com/highgag/sbook/user/controller/UserApiController.java
+++ b/src/main/java/com/highgag/sbook/user/controller/UserApiController.java
@@ -1,6 +1,7 @@
 package com.highgag.sbook.user.controller;
 
 import com.highgag.sbook.common.dto.GeneralResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import com.highgag.sbook.user.domain.User;
 import com.highgag.sbook.user.repository.UserRepository;
@@ -18,24 +19,10 @@ public class UserApiController {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    @PostMapping("join")
+    @PostMapping("user/signup")
     public GeneralResponse join(@Valid @RequestBody User user){
         user.saveUser(user.getEmail(), bCryptPasswordEncoder.encode(user.getPassword()));
         userRepository.save(user);
         return new GeneralResponse("200", "회원가입 완료");
-    }
-
-    @GetMapping("api/v1/user")
-    public String user(){
-        return "user1";
-    }
-
-    @GetMapping("api/v1/user/1")
-    public String user1(){
-        return "user1";
-    }
-    @GetMapping("api/v1/user/2")
-    public String user2(){
-        return "user1";
     }
 }

--- a/src/main/java/com/highgag/sbook/user/domain/Role.java
+++ b/src/main/java/com/highgag/sbook/user/domain/Role.java
@@ -1,5 +1,5 @@
 package com.highgag.sbook.user.domain;
 
 public enum Role {
-    ADMIN, USER
+    ROLE_ADMIN, ROLE_USER;
 }

--- a/src/main/java/com/highgag/sbook/user/domain/Role.java
+++ b/src/main/java/com/highgag/sbook/user/domain/Role.java
@@ -1,0 +1,5 @@
+package com.highgag.sbook.user.domain;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/com/highgag/sbook/user/domain/User.java
+++ b/src/main/java/com/highgag/sbook/user/domain/User.java
@@ -1,7 +1,10 @@
-package com.highgag.sbook.domain;
+package com.highgag.sbook.user.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.highgag.sbook.bookmark.domain.Bookmark;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -9,12 +12,16 @@ import java.util.List;
 
 @Entity
 @Getter
+@ToString
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     private String password;
 
@@ -23,4 +30,11 @@ public class User {
     @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Bookmark> bookmarkList = new ArrayList<>();
+
+    @Builder
+    public void saveUser(String email, String password){
+        this.email = email;
+        this.password = password;
+        this.role = Role.USER;
+    }
 }

--- a/src/main/java/com/highgag/sbook/user/domain/User.java
+++ b/src/main/java/com/highgag/sbook/user/domain/User.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@ToString
+//@ToString
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/highgag/sbook/user/domain/User.java
+++ b/src/main/java/com/highgag/sbook/user/domain/User.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.highgag.sbook.bookmark.domain.Bookmark;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -35,6 +34,6 @@ public class User {
     public void saveUser(String email, String password){
         this.email = email;
         this.password = password;
-        this.role = Role.USER;
+        this.role = Role.ROLE_USER;
     }
 }

--- a/src/main/java/com/highgag/sbook/user/dto/UserRequest.java
+++ b/src/main/java/com/highgag/sbook/user/dto/UserRequest.java
@@ -1,0 +1,19 @@
+package com.highgag.sbook.user.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class UserRequest {
+    @NotBlank
+    String email;
+
+    @NotBlank
+    String password;
+
+    public UserRequest(String email, String password){
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/highgag/sbook/user/repository/UserRepository.java
+++ b/src/main/java/com/highgag/sbook/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.highgag.sbook.user.repository;
+
+import com.highgag.sbook.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByEmail(String email);
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,16 +1,16 @@
-spring:
-  config:
-    activate:
-      on-profile: local
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/sbook_local
-    username: root
-    password:
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
+#spring:
+#  config:
+#    activate:
+#      on-profile: local
+#  datasource:
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+#    url: jdbc:mysql://127.0.0.1:3306/sbook_local
+#    username: root
+#    password:
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+#    show-sql: false
+#    properties:
+#      hibernate:
+#        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    import:
+      - classpath:/config/env.yml
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: local
+    active: production


### PR DESCRIPTION
### 인증, 인가와 관련하여 jwt 토큰을 사용
- 로그인 시, jwt 발급
- 일부 api의 경우 request header에 유효한 토큰이 필요하도록 접근 제한 (ex. /bookmark/... , /bookmarks/...)

#### 추후 추가될 기능
- exception Handler -> 토큰이 유효하지 않은 경우 401 (토큰 만료와 유효하지 않은 토큰은 각각 msg로 다르게 표시함)
- 회원가입 시 바로 token 발급
- 회원가입 시 중복 이메일 등록 제한
- credential 한 파일 관리 방법 교체